### PR TITLE
Modifications for Migration of older Versions

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -36,6 +36,12 @@
 			"description": "Allow users without an LDAP-backed ID to log into the wiki.",
 			"public": true
 		},
+		"LDAPAuthenticationUsernameNormalizer": {
+			"value": "",
+			"path": false,
+			"description": "Use this function for normalizing username for LDAP, for example 'strtolower'. Needed after migration from earlier Version.",
+			"public": true
+		},
 		"wgPluggableAuth_Class": {
 			"value": "MediaWiki\\Extension\\LDAPAuthentication\\PluggableAuth"
 		}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,5 +8,6 @@
 	"ldapauthentication-error-authentication-failed": "Could not authenticate credentials against domain \"$1\"",
 	"ldapauthentication-error-authentication-failed-userinfo": "Could not fetch required user info to complete login",
 	"ldapauthentication-no-domain-chosen": "Please choose a valid domain",
-	"ldapauthentication-no-local-login": "Local logins are not allowed"
+	"ldapauthentication-no-local-login": "Local logins are not allowed",
+	"ldapauthentication-error-local-authentication-failed": "Could not authenticate"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -4,7 +4,10 @@
 			"Robert Vogel <vogel@hallowelt.com>"
 		]
 	},
-	"ldapauthentication-desc": "{{desc|name=LDAPAuthentication|url=https://www.mediawiki.org/wiki/Extension:LDAPAuthentication}}",
-	"ldapauthentication-error-authentication-failed": "Error message in case that a login attempt failed.\nParameters:\n* $1 - The selected domain",
-	"ldapauthentication-error-authentication-failed-userinfo": "Error message in case that no user info could be retrieved from LDAP"
+	"ldapauthentication-desc": "Allows authentication against a LDAP resource",
+	"ldapauthentication-error-authentication-failed": "Could not authenticate credentials against domain \"$1\"",
+	"ldapauthentication-error-authentication-failed-userinfo": "Could not fetch required user info to complete login",
+	"ldapauthentication-no-domain-chosen": "Please choose a valid domain",
+	"ldapauthentication-no-local-login": "Local logins are not allowed",
+	"ldapauthentication-error-local-authentication-failed": "Could not authenticate"
 }


### PR DESCRIPTION
Added a Setting to re-allow strtolower, in case this was used before.
checking credentials against mediawiki user class, if local authentication is allowed.
Added one error message for failed local login and added missing qqq

example activation in LocalSettings.php :

wfLoadExtensions( [ 'LDAPProvider', 'LDAPAuthentication', 'LDAPUserInfo', 'PluggableAuth' ] );
$LDAPAuthenticationAllowLocalLogin = true;
$LDAPAuthenticationUsernameNormalizer = 'strtolower';
$LDAPProviderDomainConfigs = "/var/www/html/wiki/LDAP/extensions/LDAPProvider/ldapprovider.json";